### PR TITLE
Exercise 15: Add programmatic navigation and nested routing to `cest-la-vue`

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+node_modules

--- a/cest-la-vue/package-lock.json
+++ b/cest-la-vue/package-lock.json
@@ -18,6 +18,7 @@
         "eslint": "^9.15.0",
         "eslint-plugin-vue": "^9.31.0",
         "prettier": "^3.3.3",
+        "typescript": "^5.7.2",
         "vite": "^5.4.11",
         "vite-plugin-vue-devtools": "^7.6.4"
       }
@@ -3629,6 +3630,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.7.2.tgz",
+      "integrity": "sha512-i5t66RHxDvVN40HfDd1PsEThGNnlMCMT3jMUuoh9/0TaqWevNontacunWyN02LA9/fIbEWlcHZcgTKb9QoaLfg==",
+      "devOptional": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/universalify": {

--- a/cest-la-vue/package.json
+++ b/cest-la-vue/package.json
@@ -19,6 +19,7 @@
     "eslint": "^9.15.0",
     "eslint-plugin-vue": "^9.31.0",
     "prettier": "^3.3.3",
+    "typescript": "^5.7.2",
     "vite": "^5.4.11",
     "vite-plugin-vue-devtools": "^7.6.4"
   }

--- a/cest-la-vue/src/App.vue
+++ b/cest-la-vue/src/App.vue
@@ -4,9 +4,9 @@
   <header class="header">
     <span class="logo"> <img src="@/assets/vue-heart.png" width="30" />C'est La Vue </span>
     <nav class="nav">
-      <RouterLink to="/">Home</RouterLink>
-      <RouterLink to="/login">Login</RouterLink>
-      <RouterLink to="/users">Users</RouterLink>
+      <RouterLink to="/" active-class="active">Home</RouterLink>
+      <RouterLink to="/login" active-class="active">Login</RouterLink>
+      <RouterLink to="/users" active-class="active">Users</RouterLink>
     </nav>
   </header>
   <Suspense>
@@ -16,3 +16,9 @@
     </template>
   </Suspense>
 </template>
+
+<style scoped>
+nav a.active {
+  font-weight: bold;
+}
+</style>

--- a/cest-la-vue/src/components/UserCard.vue
+++ b/cest-la-vue/src/components/UserCard.vue
@@ -14,15 +14,35 @@ const phoneStyle: CSSProperties["font-style"] = phoneHasExtension ? "italic" : "
 const phoneWeight: CSSProperties["font-weight"] = phoneHasExtension ? "bold" : "normal";
 </script>
 
+<template>
+  <router-link :class="$style.link" :to="'/users/' + user.id">
+    <component :is="as" :class="$style.card">
+      <p :class="$style.name">{{ user.name }}</p>
+      <p>{{ user.email }}</p>
+      <p :class="$style.phone">{{ user.phone }}</p>
+    </component>
+  </router-link>
+</template>
+
 <style module>
 /* module styles work well to prevent generic classnames from leaking,
    but are a little bit tedious to use in the template */
+
+.link {
+  text-decoration: none;
+}
+
 .card {
-  background-color: goldenrod;
+  background-color: mediumaquamarine;
   padding: 0.5em;
   border-radius: 10px;
   display: grid;
   gap: 0.5em;
+
+  &:hover {
+    translate: 0 -2px;
+    box-shadow: #11222240 0 5px 5px 1px;
+  }
 }
 
 .name {
@@ -35,15 +55,3 @@ const phoneWeight: CSSProperties["font-weight"] = phoneHasExtension ? "bold" : "
   font-weight: v-bind(phoneWeight);
 }
 </style>
-
-<template>
-  <component :is="as" :class="$style.card">
-    <p :class="$style.name">{{ user.name }}</p>
-    <p>
-      <a :href="`mailto:${user.email}`">{{ user.email }}</a>
-    </p>
-    <p>
-      <a :class="$style.phone" :href="`tel:${user.phone}`">{{ user.phone }}</a>
-    </p>
-  </component>
-</template>

--- a/cest-la-vue/src/components/UserProfile.vue
+++ b/cest-la-vue/src/components/UserProfile.vue
@@ -1,0 +1,65 @@
+<script setup lang="ts">
+import type { UsersPageComponentProps } from "@/types";
+import { useRoute } from "vue-router";
+
+const route = useRoute();
+const idParam = route.params.id;
+const currentId = parseInt(Array.isArray(idParam) ? idParam[0] : idParam);
+
+const { users } = defineProps<UsersPageComponentProps>();
+const user = users.find((user) => user.id === currentId);
+</script>
+
+<template>
+  <div class="wrapper">
+    <div class="flex">
+      <RouterLink class="all-users-link" to="/users">Return to all users</RouterLink>
+      <h1>{{ user.name }}</h1>
+    </div>
+    <div class="card">
+      <dl>
+        <div class="flex" v-for="(value, key) in user" :key="`${user.id}-${key}`">
+          <dt>{{ key }}</dt>
+          <dd>{{ value }}</dd>
+        </div>
+      </dl>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.wrapper {
+  max-width: 1200px;
+  margin-inline: auto;
+}
+
+.all-users-link {
+  display: inline-block;
+  padding: 1em 0.5em;
+  margin-block: 0.5em;
+  border-radius: 0.5em;
+  background-color: mediumseagreen;
+  font-weight: bold;
+}
+
+.card {
+  background-color: mediumaquamarine;
+  padding: 0.5em;
+  border-radius: 10px;
+  display: grid;
+  gap: 0.5em;
+}
+
+.flex {
+  display: flex;
+  align-items: center;
+  gap: 1em;
+}
+
+dt {
+  font-weight: bold;
+  &::after {
+    content: ":";
+  }
+}
+</style>

--- a/cest-la-vue/src/components/UsersGrid.vue
+++ b/cest-la-vue/src/components/UsersGrid.vue
@@ -1,0 +1,27 @@
+<script setup lang="ts">
+import type { UsersPageComponentProps } from "@/types";
+import UserCard from "./UserCard.vue";
+
+const { users } = defineProps<UsersPageComponentProps>();
+</script>
+
+<template>
+  <h1>Users:</h1>
+  <ul class="user-grid">
+    <UserCard v-for="user in users" :key="user.id" :user="user" as="li" />
+  </ul>
+</template>
+
+<style scoped>
+.user-grid {
+  display: grid;
+  margin: 50px auto;
+  max-width: 1200px;
+  gap: 1em;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+
+  li {
+    list-style: none;
+  }
+}
+</style>

--- a/cest-la-vue/src/router.ts
+++ b/cest-la-vue/src/router.ts
@@ -18,6 +18,16 @@ export const router = createRouter({
     {
       path: "/users",
       component: () => import("@/views/UsersPage.vue"),
+      children: [
+        {
+          path: "",
+          component: () => import("@/components/UsersGrid.vue"),
+        },
+        {
+          path: ":id",
+          component: () => import("@/components/UserProfile.vue"),
+        },
+      ],
     },
   ],
 });

--- a/cest-la-vue/src/router.ts
+++ b/cest-la-vue/src/router.ts
@@ -12,6 +12,10 @@ export const router = createRouter({
       component: () => import("@/views/LoginPage.vue"),
     },
     {
+      path: "/dashboard/:user",
+      component: () => import("@/views/DashboardPage.vue"),
+    },
+    {
       path: "/users",
       component: () => import("@/views/UsersPage.vue"),
     },

--- a/cest-la-vue/src/types.ts
+++ b/cest-la-vue/src/types.ts
@@ -1,29 +1,33 @@
 export interface JSONPlaceholderUser {
-    id:       number;
-    name:     string;
-    username: string;
-    email:    string;
-    address:  Address;
-    phone:    string;
-    website:  string;
-    company:  Company;
+  id: number;
+  name: string;
+  username: string;
+  email: string;
+  address: Address;
+  phone: string;
+  website: string;
+  company: Company;
 }
 
 export interface Address {
-    street:  string;
-    suite:   string;
-    city:    string;
-    zipcode: string;
-    geo:     Geo;
+  street: string;
+  suite: string;
+  city: string;
+  zipcode: string;
+  geo: Geo;
 }
 
 export interface Geo {
-    lat: string;
-    lng: string;
+  lat: string;
+  lng: string;
 }
 
 export interface Company {
-    name:        string;
-    catchPhrase: string;
-    bs:          string;
+  name: string;
+  catchPhrase: string;
+  bs: string;
+}
+
+export interface UsersPageComponentProps {
+  users: JSONPlaceholderUser[];
 }

--- a/cest-la-vue/src/views/DashboardPage.vue
+++ b/cest-la-vue/src/views/DashboardPage.vue
@@ -1,0 +1,22 @@
+<script setup>
+import { useRoute } from "vue-router";
+
+const route = useRoute();
+const { user } = route.params;
+</script>
+
+<template>
+  <main>
+    <h1>Dashboard</h1>
+    <p>
+      You logged in as <span class="user">{{ user }}</span>
+    </p>
+  </main>
+</template>
+
+<style scoped>
+.user {
+  color: darkblue;
+  font-style: italic;
+}
+</style>

--- a/cest-la-vue/src/views/LoginPage.vue
+++ b/cest-la-vue/src/views/LoginPage.vue
@@ -1,11 +1,29 @@
-<script setup></script>
+<script setup lang="ts">
+import { useRouter } from "vue-router";
+
+const router = useRouter();
+
+function onLogin(event: SubmitEvent) {
+  if (!(event.target instanceof HTMLFormElement)) {
+    throw new Error("Something hit onLogin that shouldn't have");
+  }
+
+  // Let's pretend this is real auth
+  const data = new FormData(event.target);
+  const email = data.get("email");
+  const username = email.slice(0, email.toString().indexOf("@"));
+
+  router.push({ path: `/dashboard/${username}` });
+}
+</script>
 
 <template>
   <main>
     <h1>Login</h1>
-    <label for="email">Email</label>
-    <input type="email" />
-    <button>Continue with email</button>
+    <form @submit.prevent="onLogin">
+      <label for="email">Email: <input required type="email" name="email" /></label>
+      <button>Continue with email</button>
+    </form>
   </main>
 </template>
 
@@ -21,10 +39,19 @@ input[type="email"] {
 }
 
 button {
-  border: 1px solid green;
   padding: 10px;
-  color: green;
-  background-color: rgb(213, 255, 213);
-  cursor: pointer;
+
+  :has(:user-valid) & {
+    border: 1px solid green;
+    background-color: rgb(213, 255, 213);
+    color: green;
+    cursor: pointer;
+  }
+
+  :has(:user-invalid) & {
+    border: 1px solid red;
+    background-color: rgb(255, 213, 213);
+    color: red;
+  }
 }
 </style>

--- a/cest-la-vue/src/views/UsersPage.vue
+++ b/cest-la-vue/src/views/UsersPage.vue
@@ -1,36 +1,21 @@
 <script setup lang="ts">
-import { useUserStore } from "@/composables/useUserStore";
-import UserCard from "@/components/UserCard.vue";
 import Loading from "@/components/Loading.vue";
+import { useUserStore } from "@/composables/useUserStore";
 
 const { users, loadingUsers, errorGettingUsers } = useUserStore();
 </script>
-
-<style module>
-/* module styles work well to prevent generic classnames from leaking,
-   but are a little bit tedious to use in the template */
-.user-grid {
-  display: grid;
-  margin: 50px auto;
-  max-width: 1200px;
-  gap: 1em;
-  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-
-  li {
-    list-style: none;
-  }
-}
-</style>
 
 <template>
   <div>
     <div class="fullscreen-message" v-if="errorGettingUsers">Error getting users</div>
     <Loading v-else-if="loadingUsers" />
-    <div v-else>
-      <h1>Users:</h1>
-      <ul :class="$style['user-grid']">
-        <UserCard v-for="user in users" :key="user.id" :user="user" as="li" />
-      </ul>
-    </div>
+    <!-- 
+       Awkward way to pass the same props down to any child route components.
+       This works assuming they all accept the same props, which is a rare use case but fits here
+       https://router.vuejs.org/guide/essentials/passing-props.html#Via-RouterView
+      -->
+    <router-view v-else v-slot="{ Component }">
+      <component :is="Component" :users="users" />
+    </router-view>
   </div>
 </template>


### PR DESCRIPTION
# Includes:
## repo-wide, unrelated to exercise:
- Add `node_modules` to new `.prettierignore` to fix intermittently breaking Prettier

## `cest-la-vue`
### Unrelated to exercise:
- Install `typescript` to enable `defineProps<T>`
- Make the active link in header nav bold
- Update gold colors to better match Vue colors

### Related to exercise:
- Add `DashboardPage` and programmatic navigation to it from `LoginPage`
- Add nested routes in `UsersPage` to support:
  - Users are fetched once when the outer page route loads
  - Cards in nested `UserGrid` link to nested `UserProfile`
  - "Return" link in nested `UserProfile` links back to nested `UserGrid`