### PR TITLE
Exercise 16: Add pinia for state management

### DIFF
--- a/cest-la-vue/package-lock.json
+++ b/cest-la-vue/package-lock.json
@@ -8,6 +8,7 @@
       "name": "cest-la-vue",
       "version": "0.0.0",
       "dependencies": {
+        "pinia": "^2.2.8",
         "vue": "^3.5.13",
         "vue-router": "^4.5.0"
       },
@@ -3299,6 +3300,56 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pinia": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/pinia/-/pinia-2.2.8.tgz",
+      "integrity": "sha512-NRTYy2g+kju5tBRe0oNlriZIbMNvma8ZJrpHsp3qudyiMEA8jMmPPKQ2QMHg0Oc4BkUyQYWagACabrwriCK9HQ==",
+      "dependencies": {
+        "@vue/devtools-api": "^6.6.3",
+        "vue-demi": "^0.14.10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.4.0",
+        "typescript": ">=4.4.4",
+        "vue": "^2.6.14 || ^3.5.11"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        },
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/pinia/node_modules/vue-demi": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.10.tgz",
+      "integrity": "sha512-nMZBOwuzabUO0nLgIcc6rycZEebF6eeUfaiQx9+WSk8e29IbLvPU9feI6tqW4kTo3hvoYAJkMh8n8D0fuISphg==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
       }
     },
     "node_modules/postcss": {

--- a/cest-la-vue/package.json
+++ b/cest-la-vue/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs --fix --ignore-path .gitignore"
   },
   "dependencies": {
+    "pinia": "^2.2.8",
     "vue": "^3.5.13",
     "vue-router": "^4.5.0"
   },

--- a/cest-la-vue/src/components/UserProfile.vue
+++ b/cest-la-vue/src/components/UserProfile.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
-import type { UsersPageComponentProps } from "@/types";
+import { useUserStore } from "@/stores/useUserStore";
+import { computed } from "vue";
 import { useRoute } from "vue-router";
 
 const route = useRoute();
-const idParam = route.params.id;
-const currentId = parseInt(Array.isArray(idParam) ? idParam[0] : idParam);
+const { userByIdParam } = useUserStore();
 
-const { users } = defineProps<UsersPageComponentProps>();
-const user = users.find((user) => user.id === currentId);
+// computed() ensures we get the new user if the route changes
+const user = computed(() => userByIdParam(route.params.id));
 </script>
 
 <template>

--- a/cest-la-vue/src/components/UsersGrid.vue
+++ b/cest-la-vue/src/components/UsersGrid.vue
@@ -1,8 +1,11 @@
 <script setup lang="ts">
-import type { UsersPageComponentProps } from "@/types";
+import { useUserStore } from "@/stores/useUserStore";
 import UserCard from "./UserCard.vue";
 
-const { users } = defineProps<UsersPageComponentProps>();
+// This doesn't to be reactive, because it:
+// 1. has to have loaded by the time this component renders, and
+// 2. won't be updated after the initial load
+const { users } = useUserStore();
 </script>
 
 <template>

--- a/cest-la-vue/src/main.ts
+++ b/cest-la-vue/src/main.ts
@@ -2,8 +2,12 @@ import { createApp } from "vue";
 import App from "./App.vue";
 import "./assets/common.css";
 import { router } from "./router";
+import { createPinia } from "pinia";
 
 const app = createApp(App);
+const pinia = createPinia();
+
 app.use(router);
+app.use(pinia);
 
 app.mount("#app");

--- a/cest-la-vue/src/stores/useUserStore.ts
+++ b/cest-la-vue/src/stores/useUserStore.ts
@@ -1,7 +1,9 @@
 import { ref } from "vue";
 import type { JSONPlaceholderUser } from "../types";
+import { defineStore } from "pinia";
 
-export function useUserStore() {
+// We can pass a setup function into defineStore to use the composition API
+export const useUserStore = defineStore("UserStore", function () {
   // Seems like we have to use separate refs here (not reactive) so we can update states separately
   // https://router.vuejs.org/guide/advanced/data-fetching.html
   const users = ref<JSONPlaceholderUser[]>([]);
@@ -34,5 +36,10 @@ export function useUserStore() {
     }
   })();
 
-  return { users, loadingUsers, errorGettingUsers };
-}
+  function userByIdParam(idParam: string | string[]) {
+    const currentId = parseInt(Array.isArray(idParam) ? idParam[0] : idParam);
+    return users.value.find((user) => user.id === currentId);
+  }
+
+  return { users, loadingUsers, errorGettingUsers, userByIdParam };
+});

--- a/cest-la-vue/src/views/UsersPage.vue
+++ b/cest-la-vue/src/views/UsersPage.vue
@@ -1,21 +1,18 @@
 <script setup lang="ts">
 import Loading from "@/components/Loading.vue";
-import { useUserStore } from "@/composables/useUserStore";
+import { useUserStore } from "@/stores/useUserStore";
+import { storeToRefs } from "pinia";
 
-const { users, loadingUsers, errorGettingUsers } = useUserStore();
+const userStore = useUserStore();
+
+// storeToRefs keeps these reactive
+const { errorGettingUsers, loadingUsers } = storeToRefs(userStore);
 </script>
 
 <template>
   <div>
     <div class="fullscreen-message" v-if="errorGettingUsers">Error getting users</div>
     <Loading v-else-if="loadingUsers" />
-    <!-- 
-       Awkward way to pass the same props down to any child route components.
-       This works assuming they all accept the same props, which is a rare use case but fits here
-       https://router.vuejs.org/guide/essentials/passing-props.html#Via-RouterView
-      -->
-    <router-view v-else v-slot="{ Component }">
-      <component :is="Component" :users="users" />
-    </router-view>
+    <router-view v-else />
   </div>
 </template>


### PR DESCRIPTION
Adds `pinia` to handle state management and moves the `useUserStore` composable into a Pinia store.

With state managed in pinia, the Users page (accessed through either `/users` or `/users/id`) can now be left and returned to without refetching users from the API.